### PR TITLE
fix when request comes from curl

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,5 +20,5 @@ def get_locale():
 
 @app.route('/')
 def home():
-    g.lang_code = request.accept_languages.best_match(app.config['LANGUAGES'])
+    if request.accept_languages.best_match(app.config['LANGUAGES']) == None: g.lang_code = app.config['LANGUAGES'][0]
     return redirect(url_for('multilingual.index'))


### PR DESCRIPTION
When access is through curl or using google console, the server responds 500.

This solution takes the first element of the language array if not exist the language from the browser.

Before de change:

![Screen Shot 2021-02-22 at 15 25 01](https://user-images.githubusercontent.com/8621547/108755818-7c53b600-7526-11eb-9ab5-1476a467fd75.png)

![Screen Shot 2021-02-22 at 15 23 29](https://user-images.githubusercontent.com/8621547/108755753-67772280-7526-11eb-8b52-7c9be28b0eab.png)


After the change:
![Screen Shot 2021-02-22 at 15 57 14](https://user-images.githubusercontent.com/8621547/108755932-a3aa8300-7526-11eb-8a20-8da18dc80d6d.png)

